### PR TITLE
Command-line utility (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PyPI version](https://badge.fury.io/py/magnetsdk2.svg)](https://badge.fury.io/py/magnetsdk2)
+
 # Niddel Magnet v2 API Python SDK
 
 A simple client that allows idiomatic access to the 
@@ -88,3 +90,61 @@ Though the provided implementation saves the data to a JSON file, it is easy to 
 means of persistence by creating subclasses of 
 `magnetsdk2.iterator.AbstractPersistentAlertIterator` that implement the abstract `_save`
 and `_load` methods.
+
+
+## Command-line Utility
+
+Starting with version 1.2.0, the package installs a `niddel` command-line utility which
+can be used to perform most of the same functionalities available on the SDK. First install
+the package:
+```bash
+$ pip install magnetsdk2
+```
+
+Then, you can see that a `--profile` option can be provided to select an alternative API key
+from `~/.magnetsdk/config`, as described previously:
+```bash
+$ niddel -h
+usage: niddel [-h] [-p PROFILE] [-i] [-v] {me,organizations,alerts} ...
+
+Command-line utility to interact with the Niddel Magnet v2 API
+
+positional arguments:
+  {me,organizations,alerts}
+    me                  display API key owner information
+    organizations       list basic organization information
+    alerts              list an organization's alerts
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PROFILE, --profile PROFILE
+                        which profile (from ~/.magnetsdk/config) to obtain API
+                        key from
+  -i, --indent          indent JSON output
+  -v, --verbose         set verbose mode
+```
+
+You can even use a persistent alert iterator by providing a file name with `--persist` when listing
+alerts:
+```bash
+$ niddel alerts -h
+usage: niddel alerts [-h] [--start START] [-p PERSIST] organization
+
+list an organization's alerts
+
+positional arguments:
+  organization          ID of the organization
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --start START         initial batch date to process in YYYY-MM-DD format
+  -p PERSIST, --persist PERSIST
+                        file to store persistent state data, to ensure only
+                        alerts that haven't been seen before are part of the
+                        output
+```
+
+Keep in mind that the persistence state is only saved immediately before the command exits, after
+all unprocessed alerts have been printed to stdout. So if the CLI utility is interrupted or if an 
+exception occurs mid-processing, no state is saved and any alerts output in this failed execution 
+are not considered processed.

--- a/magnetsdk2/cli.py
+++ b/magnetsdk2/cli.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""
+This module implements the CLI tool 'niddel' that can be used to interact with the Niddel Magnet
+v2 API using magnetsdk2.
+"""
+
+import argparse
+import json
+import logging
+from sys import stderr
+from uuid import UUID
+
+from magnetsdk2 import Connection
+from magnetsdk2.iterator import FilePersistentAlertIterator
+from magnetsdk2.validation import parse_date
+
+logger = logging.getLogger('magnetsdk2')
+handler = logging.StreamHandler(stderr)
+handler.setFormatter(
+    logging.Formatter('%(asctime)s pid=%(process)d %(module)s %(levelname)s %(message)s',
+                      '%Y-%m-%dT%H:%M:%S%z'))
+logger.addHandler(handler)
+
+
+def main():
+    # top-level parser
+    parser = argparse.ArgumentParser(prog='niddel',
+                                     description='Command-line utility to interact with the ' +
+                                                 'Niddel Magnet v2 API')
+    parser.add_argument("-p", "--profile",
+                        help="which profile (from ~/.magnetsdk/config) to obtain API key from",
+                        default='default')
+    parser.add_argument("-i", "--indent", help="indent JSON output", action="store_const", const=4)
+    parser.add_argument("-v", "--verbose", help="set verbose mode", action="store_true",
+                        default=False)
+    parser.set_defaults(indent=None)
+    subparsers = parser.add_subparsers()
+
+    # "me" command
+    me_parser = subparsers.add_parser('me', help="display API key owner information",
+                                      description="display API key owner information")
+    me_parser.set_defaults(func=command_me)
+
+    # "organizations" command
+    org_parser = subparsers.add_parser('organizations',
+                                       help="list basic organization information",
+                                       description="list basic organization information")
+    org_parser.add_argument("--id", help="get details on organization with the provided ID",
+                            type=UUID, required=False)
+    org_parser.set_defaults(func=command_organizations, id=None)
+
+    # "alerts" command
+    alerts_parser = subparsers.add_parser('alerts',
+                                          help="list an organization's alerts",
+                                          description="list an organization's alerts")
+    alerts_parser.add_argument("organization", help="ID of the organization",
+                               type=UUID)
+    alerts_parser.add_argument("--start", help="initial batch date to process in YYYY-MM-DD format",
+                               type=parse_arg_date)
+    alerts_parser.add_argument("-p", "--persist",
+                               help="file to store persistent state data, to ensure only alerts " +
+                                    "that haven't been seen before are part of the output")
+    alerts_parser.set_defaults(func=command_alerts, start=None, persist=None)
+
+    # parse arguments, open connection and dispatch to proper function
+    args = parser.parse_args()
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+    conn = Connection(profile=args.profile)
+    args.func(conn, args)
+
+
+def parse_arg_date(value):
+    try:
+        return parse_date(value)
+    except:
+        raise argparse.ArgumentTypeError("unable to parse date, YYYY-MM-DD format expected")
+
+
+def command_me(conn, args):
+    print json.dumps(conn.get_me(), indent=args.indent)
+
+
+def command_organizations(conn, args):
+    if args.id:
+        print json.dumps(conn.get_organization(args.id.__str__()), indent=args.indent)
+    else:
+        for organization in conn.iter_organizations():
+            print json.dumps(organization, indent=args.indent)
+
+
+def command_alerts(conn, args):
+    if args.persist:
+        iterator = FilePersistentAlertIterator(filename=args.persist, connection=conn,
+                                               organization_id=args.organization.__str__(),
+                                               start_date=args.start)
+    else:
+        iterator = conn.iter_organization_alerts(organization_id=args.organization.__str__(),
+                                                 fromDate=args.start, sortBy='batchDate')
+    for alert in iterator:
+        print json.dumps(alert, indent=args.indent)
+
+    if args.persist:
+        iterator.save()
+
+
+if __name__ == "__main__":
+    main()

--- a/magnetsdk2/connection.py
+++ b/magnetsdk2/connection.py
@@ -310,7 +310,7 @@ class Connection(object):
                 return
             else:
                 response.raise_for_status()
-            params['pae'] += 1
+            params['page'] += 1
 
     def list_organization_alert_dates(self, organization_id, sortBy="logDate"):
         """ Lists all log or batch dates for which alerts exist on the organization.

--- a/magnetsdk2/version.py
+++ b/magnetsdk2/version.py
@@ -1,5 +1,5 @@
 """
 Version info for magnetsdk2.
 """
-__version_info__ = (1, 1, 0)
+__version_info__ = (1, 2, 0)
 __version__ = ".".join(map(str, __version_info__))

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,8 @@ setup(
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Libraries :: Application Frameworks'
-    ]
+    ],
+    entry_points = {
+        'console_scripts': ['niddel=magnetsdk2.cli:main']
+    }
 )


### PR DESCRIPTION
* Added `niddel` command-line utility that allows read access to API key own, organization and alert information;
* Fixed typo that caused an error on calls to `Connection.iter_organization_alerts` when more than 100 alerts were available;
* Updated version to 1.2.0.