### PR TITLE
White/black lists and default organizations (resolves #2, resolves #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A simple client that allows idiomatic access to the
 [Niddel Magnet v2 REST API](https://api.niddel.com/v2). Uses the wonderful
 [requests](http://docs.python-requests.org/) package to perform the requests.
 
+Release history: [https://github.com/Niddel/magnet-api2-sdk-python/releases](https://github.com/Niddel/magnet-api2-sdk-python/releases)
+
 ## Configuring Credentials
 
 There are a couple of ways to let the `Connection` object know which API key to use.

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ REST API <https://api.niddel.com/v2>`__. Uses the wonderful
 `requests <http://docs.python-requests.org/>`__ package to perform the
 requests.
 
+Release history:
+https://github.com/Niddel/magnet-api2-sdk-python/releases
+
 Configuring Credentials
 -----------------------
 

--- a/magnetsdk2/__init__.py
+++ b/magnetsdk2/__init__.py
@@ -4,7 +4,7 @@ A simple client that allows idiomatic access to the Niddel Magnet v2 REST API
 (https://api.niddel.com/v2). Uses the wonderful requests (http://docs.python-requests.org/)
 package to perform the requests.
 """
-__version__ = '1.4.1'
+__version__ = '1.5.0'
 
 # set up package logger
 import logging

--- a/magnetsdk2/connection.py
+++ b/magnetsdk2/connection.py
@@ -224,7 +224,7 @@ class Connection(object):
         """
         if not is_valid_uuid(organization_id):
             raise ValueError("organization id should be a string in UUID format")
-        response = self._request_retry("GET", path='organizations/' + organization_id)
+        response = self._request_retry("GET", path='organizations/%s' % organization_id)
         if response.status_code == 200:
             return response.json()
         elif response.status_code == 404:
@@ -342,3 +342,67 @@ class Connection(object):
             return response.json()
         else:
             response.raise_for_status()
+
+    def _list_organization_wblists(self, scope, organization_id):
+        if not scope in ('white', 'black',):
+            raise ValueError('scope should be either white or black')
+        if not is_valid_uuid(organization_id):
+            raise ValueError("organization id should be a string in UUID format")
+
+        path = 'organizations/%s/%slists' % (organization_id, scope)
+        response = self._request_retry("GET", path=path)
+        if response.status_code == 200:
+            return response.json()
+        elif response.status_code == 404:
+            return []
+        else:
+            response.raise_for_status()
+
+    def list_organization_whitelists(self, organization_id):
+        """
+        Lists the white list entries of an organization.
+        :param organization_id: the organization ID
+        :return: a list of dicts representing white list entries
+        """
+        return self._list_organization_wblists('white', organization_id)
+
+    def list_organization_blacklists(self, organization_id):
+        """
+        Lists the black list entries of an organization.
+        :param organization_id: the organization ID
+        :return: a list of dicts representing black list entries
+        """
+        return self._list_organization_wblists('black', organization_id)
+
+    def _get_organization_wblist_entry(self, scope, organization_id, id):
+        if not scope in ('white', 'black',):
+            raise ValueError('scope should be either white or black')
+        if not is_valid_uuid(organization_id):
+            raise ValueError("organization id should be a string in UUID format")
+        if not is_valid_uuid(organization_id):
+            raise ValueError("id should be a string in UUID format")
+
+        path = 'organizations/%s/%slists/%s' % (organization_id, scope, id)
+        response = self._request_retry("GET", path=path)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            response.raise_for_status()
+
+    def get_organization_whitelists(self, organization_id, id):
+        """
+        Retrieves the details of a the white list entry.
+        :param organization_id: the organization ID
+        :param id: the white list entry ID
+        :return: a dict representing a white list entry
+        """
+        return self._get_organization_wblist_entry('white', organization_id, id)
+
+    def get_organization_blacklists(self, organization_id, id):
+        """
+        Retrieves the details of a the black list entry.
+        :param organization_id: the organization ID
+        :param id: the black list entry ID
+        :return: a dict representing a black list entry
+        """
+        return self._get_organization_wblist_entry('black', organization_id, id)

--- a/magnetsdk2/validation.py
+++ b/magnetsdk2/validation.py
@@ -5,6 +5,7 @@ This module implements basic validation and conversion logic for API data.
 import datetime
 import re
 from collections import Iterable
+from uuid import UUID
 
 import iso8601
 import rfc3987
@@ -19,7 +20,8 @@ def is_valid_uuid(value):
     :param value: string to validate
     :return: a boolean
     """
-    return isinstance(value, six.string_types) and _UUID_REGEX.match(value)
+    return isinstance(value, UUID) or \
+           (isinstance(value, six.string_types) and _UUID_REGEX.match(value))
 
 
 def is_valid_uri(value):


### PR DESCRIPTION
* Connection class will now access instances of uuid.UUID class as ID values.
* Added new Connection class methods to allow white and black list entries to be listed.
* CLI positional organization ID parameters are now optional, and the API key owner's default organization ID is used by default. This will make life simpler for most users, who have access to a single organization.
* Added new CLI commands `whitelists` and `blacklists`.
* Bumped version to 1.5.0.